### PR TITLE
Densya_de_go の変更点について

### DIFF
--- a/densya_de_go.ino
+++ b/densya_de_go.ino
@@ -23,8 +23,8 @@
 //  定義マクロ
 //--------------------------------------------------------------------
 
-#define PWMOUT 3
-#define PWMIN  4
+#define PWMOUT1   9
+#define PWMOUT2  10
 
 //====================================================================
 //  大域宣言
@@ -82,10 +82,9 @@ void setup()
 
     // Poll current state once.
     PSX.updateState(PSX_PAD1);
-    // 3ピンからpwm出力
-    pinMode( PWMOUT, OUTPUT );
-    // 4ピンは入力
-    pinMode( PWMIN, OUTPUT );
+    // 9,10ピンからpwm出力
+    pinMode( PWMOUT1, OUTPUT );
+    pinMode( PWMOUT2, OUTPUT );
 }
 
 //====================================================================
@@ -109,10 +108,10 @@ void loop()
     Serial.println(speed);
 
     // pwm出力
-    analogWrite( PWMOUT, speed );
-    digitalWrite( PWMIN, LOW );
+    analogWrite( PWMOUT1, speed );
+    analogWrite( PWMOUT2, 0);
 
-    delay(100);
+    delay(50);      // ポーリング間隔が65msを超えるとワンハンドルタイプは取得不可になる。
 }
 
 


### PR DESCRIPTION
はじめまして。
KeKe115様が作成された、電車でGOのコントローラの制御プログラムを参考にして dengo_ts_emu というTSマスコンをエミュレートするプログラムを作成しました。
densya_de_go.ino は、わかりやすく書かれており、特にハンドル位置を取得するボタンの組み合わせについては大変参考になりました。

プログラムを拝見して、いくつか気づいた点がありますので、モディファイを行いました。

- PWMOUT が 3, PWMIN が 4 と定義されていますが、Playsation2 controller interface library for Arduino でハードコードされているものと競合しています。ライブラリもしくはこのプログラムのピン番号を変更したほうが良いように思います。
→ こちらのコードのピンを 9,10 に変更しました。

- 「4ピンは入力」とのコメントがありましたが、pinMode( PWMIN, OUTPUT ); で出力になっています。また、loop関数内でLowに出力しています。
→ TA8428K の制御ピンと思われますので、ピンの名前とコメントを修正し、PWM出力に変更した上で、出力をL固定にしました。

- ワンハンドルタイプでは動作しませんでした。
→ ワンハンドルタイプはポーリング間隔が65msを超えると応答しなくなるためです。加速度が2倍になってしまいますが、ポーリング間隔を50msとしました。


既に最終更新から5年以上経過しておりますが、せっかくオープンソースで公開されているので、他の方の参考になればと思い、PullRequestをかけさせていただきました。
